### PR TITLE
Fix CodeQL issues with CMakeLists.txt

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -40,10 +40,9 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v2
       with:
-        submodules: false
+        submodules: true
 
     - run: mkdir ${{github.workspace}}/build/Debug
-    - run: mkdir ${{github.workspace}}/build/wxSnapshot/Debug
 
     - name: Configure CMake
       run: cmake -G "Visual Studio 16 2019" -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,12 +8,12 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 
 if (MSVC)
     # /O1 often results in faster code than /O2 due to CPU caching
-    string(REPLACE "/O2" "/O1" cl_optimize ${CMAKE_CXX_FLAGS_RELEASE})
+    string(REPLACE "/O2" "/O1" cl_optimize "${CMAKE_CXX_FLAGS_RELEASE}")
     set(CMAKE_CXX_FLAGS_RELEASE ${cl_optimize} CACHE STRING "C++ Release flags" FORCE)
 
     # Using /Z7 instead of /Zi to avoid blocking while parallel compilers write to the pdb file.
     # This can considerably speed up build times at the cost of larger object files.
-    string(REPLACE "/Zi" "/Z7" z_seven ${CMAKE_CXX_FLAGS_DEBUG})
+    string(REPLACE "/Zi" "/Z7" z_seven "${CMAKE_CXX_FLAGS_DEBUG}")
     set(CMAKE_CXX_FLAGS_DEBUG ${z_seven} CACHE STRING "C++ Debug flags" FORCE)
 
     # Use static runtime for Release builds to run with Wine without needing to install the dlls
@@ -21,7 +21,7 @@ if (MSVC)
 else()
     # This should work for gcc and clang (including xcode which is based on clang)
     # -O2 can result in faster code than -O3 due to CPU caching.
-    string(REPLACE "-O3" "-O2" cl_optimize ${CMAKE_CXX_FLAGS_RELEASE})
+    string(REPLACE "-O3" "-O2" cl_optimize "${CMAKE_CXX_FLAGS_RELEASE}")
     set(CMAKE_CXX_FLAGS_RELEASE ${cl_optimize} CACHE STRING "C++ Release flags" FORCE)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,9 +52,7 @@ if (INTERNAL_WIDGETS_SOURCES)
 endif()
 
 set (widget_dir ${CMAKE_CURRENT_LIST_DIR}/wxSnapshot)
-set (widget_lib_dir ${CMAKE_CURRENT_LIST_DIR}/wxSnapshot/build)
 set (widget_cmake_dir ${CMAKE_CURRENT_LIST_DIR}/wxSnapshot)
-
 add_subdirectory(${widget_cmake_dir})
 
 add_compile_definitions($<$<CONFIG:Release>:NDEBUG>)


### PR DESCRIPTION
CodeQL now checks the CMakeLists.txt file before setting the CMAKE_CXX_FLAGS_RELEASE macro, causing REPLACE to fail unless the macro is in quotes.

Picked up the fix in the sub-module wxSnapshot as well.

<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
