### PR TITLE
Regenerate after fix for #1518

### DIFF
--- a/sdi/python/bitmaps_dlg.py
+++ b/sdi/python/bitmaps_dlg.py
@@ -134,7 +134,8 @@ class BitmapsDlg(wx.Dialog):
         dlg_sizer.Add(grid_sizer, wx.SizerFlags().Border(wx.ALL))
 
         if "wxMac" not in wx.PlatformInfo:
-            stdBtn_line = wx.StaticLine(self, wx.ID_ANY, wx.DefaultPosition, wx.Size(20, -1))
+            stdBtn_line = \
+                wx.StaticLine(self, wx.ID_ANY, wx.DefaultPosition, wx.Size(20, -1))
             dlg_sizer.Add(stdBtn_line, wx.SizerFlags().Expand().Border(wx.ALL))
 
         stdBtn = wx.StdDialogButtonSizer()

--- a/sdi/python/booktest_dlg.py
+++ b/sdi/python/booktest_dlg.py
@@ -461,17 +461,18 @@ class BookTestDlg(wx.Dialog):
         page2.SetSizerAndFit(page_sizer2)
 
         if "wxMac" not in wx.PlatformInfo:
-            stdBtn_line = wx.StaticLine(self, wx.ID_ANY, wx.DefaultPosition, wx.Size(20, -1))
-            dlg_sizer.Add(stdBtn_line, wx.SizerFlags().Expand().Border(wx.ALL))
+            self.stdBtn_line = \
+                wx.StaticLine(self, wx.ID_ANY, wx.DefaultPosition, wx.Size(20, -1))
+            dlg_sizer.Add(self.stdBtn_line, wx.SizerFlags().Expand().Border(wx.ALL))
 
-        stdBtn = wx.StdDialogButtonSizer()
-        stdBtn_OK = wx.Button(self, wx.ID_OK)
-        stdBtn.SetAffirmativeButton(stdBtn_OK)
-        stdBtn_Cancel = wx.Button(self, wx.ID_CANCEL)
-        stdBtn.SetCancelButton(stdBtn_Cancel)
-        stdBtn_OK.SetDefault()
-        stdBtn.Realize()
-        dlg_sizer.Add(stdBtn, wx.SizerFlags().Expand().Border(wx.ALL))
+        self.stdBtn = wx.StdDialogButtonSizer()
+        self.stdBtn_OK = wx.Button(self, wx.ID_OK)
+        self.stdBtn.SetAffirmativeButton(self.stdBtn_OK)
+        self.stdBtn_Cancel = wx.Button(self, wx.ID_CANCEL)
+        self.stdBtn.SetCancelButton(self.stdBtn_Cancel)
+        self.stdBtn_OK.SetDefault()
+        self.stdBtn.Realize()
+        dlg_sizer.Add(self.stdBtn, wx.SizerFlags().Expand().Border(wx.ALL))
 
         if pos != wx.DefaultPosition:
             self.SetPosition(self.FromDIP(pos))
@@ -495,12 +496,9 @@ class BookTestDlg(wx.Dialog):
         self.btn2.Bind(wx.EVT_BUTTON, self.on_button)
         self.btn4.Bind(wx.EVT_BUTTON, self.on_button)
 
-    # Event handler functions
-    # Add these below the comment block, or to your inherited class.
+    # Unimplemented Event handler functions
+    # Copy any listed and paste them below the comment block, or to your inherited class.
     """
-    def on_button(self, event):
-        event.Skip()
-
     """
 
 # ************* End of generated code ***********
@@ -509,3 +507,6 @@ class BookTestDlg(wx.Dialog):
 # Code below this comment block will be preserved
 # if the code for this class is re-generated.
 # ***********************************************
+
+    def on_button(self, event):
+        event.Skip()

--- a/sdi/python/dlgissue_956.py
+++ b/sdi/python/dlgissue_956.py
@@ -61,7 +61,8 @@ class DlgIssue_956(wx.Dialog):
         panel_2.SetSizerAndFit(grid_bag_sizer)
 
         if "wxMac" not in wx.PlatformInfo:
-            stdBtn_line = wx.StaticLine(self, wx.ID_ANY, wx.DefaultPosition, wx.Size(20, -1))
+            stdBtn_line = \
+                wx.StaticLine(self, wx.ID_ANY, wx.DefaultPosition, wx.Size(20, -1))
             dlg_sizer.Add(stdBtn_line, wx.SizerFlags().Expand().Border(wx.ALL))
 
         stdBtn = wx.StdDialogButtonSizer()

--- a/sdi/python/dlgissue_960.py
+++ b/sdi/python/dlgissue_960.py
@@ -46,7 +46,8 @@ class DlgIssue_960(wx.Dialog):
         dlg_sizer.Add(bmp_3, wx.SizerFlags().Border(wx.ALL))
 
         if "wxMac" not in wx.PlatformInfo:
-            stdBtn_line = wx.StaticLine(self, wx.ID_ANY, wx.DefaultPosition, wx.Size(20, -1))
+            stdBtn_line = \
+                wx.StaticLine(self, wx.ID_ANY, wx.DefaultPosition, wx.Size(20, -1))
             dlg_sizer.Add(stdBtn_line, wx.SizerFlags().Expand().Border(wx.ALL))
 
         stdBtn = wx.StdDialogButtonSizer()

--- a/sdi/python/main_test_dlg.py
+++ b/sdi/python/main_test_dlg.py
@@ -768,7 +768,8 @@ class MainTestDialog(wx.Dialog):
         dlg_sizer.Add(self.events_list, wx.SizerFlags(1).Expand().Border(wx.ALL))
 
         if "wxMac" not in wx.PlatformInfo:
-            stdBtn_line = wx.StaticLine(self, wx.ID_ANY, wx.DefaultPosition, wx.Size(20, -1))
+            stdBtn_line = \
+                wx.StaticLine(self, wx.ID_ANY, wx.DefaultPosition, wx.Size(20, -1))
             dlg_sizer.Add(stdBtn_line, wx.SizerFlags().Expand().Border(wx.ALL))
 
         stdBtn = wx.StdDialogButtonSizer()

--- a/sdi/python/python_dlg.py
+++ b/sdi/python/python_dlg.py
@@ -83,7 +83,8 @@ class PythonDlg(wx.Dialog):
         bSizer1.Add(box_sizer, wx.SizerFlags().Expand().Border(wx.ALL))
 
         if "wxMac" not in wx.PlatformInfo:
-            stdBtn_line = wx.StaticLine(self, wx.ID_ANY, wx.DefaultPosition, wx.Size(20, -1))
+            stdBtn_line = \
+                wx.StaticLine(self, wx.ID_ANY, wx.DefaultPosition, wx.Size(20, -1))
             bSizer1.Add(stdBtn_line, wx.SizerFlags().Expand().Border(wx.ALL))
 
         stdBtn = wx.StdDialogButtonSizer()

--- a/sdi/sdi_test.wxui
+++ b/sdi/sdi_test.wxui
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <wxUiEditorData
-  data_version="21">
+  data_version="17">
   <node
     class="Project"
     art_directory="../art"
@@ -11,7 +11,6 @@
     cpp_line_length="125"
     derived_directory="cpp"
     generate_cmake="1"
-    wxWidgets_version="3.2"
     python_output_folder="python"
     ruby_output_folder="ruby"
     combine_all_forms="0"
@@ -1753,6 +1752,8 @@
         </node>
         <node
           class="wxStdDialogButtonSizer"
+          class_access="protected:"
+          var_name="m_stdBtn"
           flags="wxEXPAND" />
       </node>
     </node>


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
Used to verify fix for https://github.com/KeyWorksRW/wxUiEditor/issues/1518

While several dialogs had class access to stdBtn, this PR adds one where the line length resulted in the line
breaking.
